### PR TITLE
Handle NULL values in hash calculation for accurate data comparison

### DIFF
--- a/src/DB/Data/LocalTableData.php
+++ b/src/DB/Data/LocalTableData.php
@@ -110,7 +110,7 @@ class LocalTableData {
 
         $wrapCast = function($arr, $p) {
             return array_map(function($el) use ($p) {
-                return "CAST(`{$p}`.`{$el}` AS CHAR CHARACTER SET utf8)";
+                return "COALESCE(CAST(`{$p}`.`{$el}` AS CHAR CHARACTER SET utf8), '')";
             }, $arr);
         };
 


### PR DESCRIPTION
#### Context:
While working with DBDiff to compare data and schema, an issue was identified in the handling of `NULL` values during data comparison. Specifically, when columns containing `NULL` values were included in the MD5 hash computation, the results were inconsistent. This issue was due to the behavior of `CONCAT` in SQL, which returns `NULL` if any of the values being concatenated are `NULL`.

#### Root Cause:
When constructing MD5 hashes for row comparisons, the query builder used `CONCAT` without handling `NULL` values. This led to `NULL` hashes, causing incorrect identification of rows as identical even when there were clear differences.

For example:
```sql
SELECT CONCAT('value', NULL);  -- Result is NULL as shown below
+-----------------------+
| CONCAT('value', NULL) |
+-----------------------+
| NULL                  |
+-----------------------+
